### PR TITLE
Update backend to match statsd graphite backend at v0.7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,27 @@ Place **hostedgraphite.js** into the **backends/** directory of your **statsd** 
 
 ## Configuration
 
+Accepts same configuration options as [graphite](https://github.com/etsy/statsd/blob/v0.7.2/exampleConfig.js#L65).
+
+```
+hostedGraphite:
+    legacyNamespace:  use the legacy namespace [default: true]
+    globalPrefix:     global prefix to use for sending stats to graphite [default: "stats"]
+    prefixCounter:    graphite prefix for counter metrics [default: "counters"]
+    prefixTimer:      graphite prefix for timer metrics [default: "timers"]
+    prefixGauge:      graphite prefix for gauge metrics [default: "gauges"]
+    prefixSet:        graphite prefix for set metrics [default: "sets"]
+    globalSuffix:     global suffix to use for sending stats to graphite [default: ""]
+                      This is particularly useful for sending per host stats by
+                      settings this value to: require('os').hostname().split('.')[0]
+```
+
 ### Enabling the plugin
 
 Add './backends/hostedgraphite' to the ```backends``` list.
 
 ```
-	backends: ['./backends/hostedgraphite']
+backends: ['./backends/hostedgraphite']
 ```
 
 ### Setting the Hosted Graphite key
@@ -21,7 +36,7 @@ Add './backends/hostedgraphite' to the ```backends``` list.
 Set ```hostedGraphiteAPIKey``` to your key. This looks like a UUID and is available from your account details page on [hostedgraphite.com](hostedgraphite.com)
 
 ```
-	hostedGraphiteAPIKey: 'deadbeef-dead-beef-dead-beefdeadbeef'
+hostedGraphiteAPIKey: 'deadbeef-dead-beef-dead-beefdeadbeef'
 ```
 
 ## Example configuration
@@ -31,5 +46,8 @@ Set ```hostedGraphiteAPIKey``` to your key. This looks like a UUID and is availa
       port: 8125
    ,  backends: ['./backends/hostedgraphite']
    ,  hostedGraphiteAPIKey: 'deadbeef-dead-beef-dead-beefdeadbeef'
+   ,  hostedGraphite: {
+          legacyNamespace: false
+      }
 }
 ```

--- a/hostedgraphite.js
+++ b/hostedgraphite.js
@@ -12,137 +12,258 @@
  */
 
 var net = require('net'),
-   util = require('util'),
    http = require('http');
 
+// this will be instantiated to the logger
+var l;
+
 var debug;
+var apiKey;
 var flushInterval;
-var APIKey;
+var flush_counts;
+
+// prefix configuration
+var globalPrefix;
+var prefixCounter;
+var prefixTimer;
+var prefixGauge;
+var prefixSet;
+var globalSuffix;
+var prefixStats;
+var globalKeySanitize = true;
+
+// set up namespaces
+var legacyNamespace  = true;
+var globalNamespace  = [];
+var counterNamespace = [];
+var timerNamespace   = [];
+var gaugesNamespace  = [];
+var setsNamespace    = [];
 
 var graphiteStats = {};
 
 var post_stats = function graphite_post_stats(statString) {
-  var options = {
-    host: 'www.hostedgraphite.com',
-    port: 80,
-    path: '/api/v1/sink',
-    method: 'POST',
-    auth: APIKey,
-    headers: {'Content-Length': statString.length}
-  };
-  
-  var req = http.request(options, function(res) {
-    if (res.statusCode == 202) {
-       graphiteStats.last_flush = Math.round(new Date().getTime() / 1000);
-    }
-  });
-  
-  req.on('error', function(ex) {
-    graphiteStats.last_exception = Math.round(new Date().getTime() / 1000);
-    if (debug) {
-      util.log(ex);
-    }
-  });
-  
-  req.write(statString);
-  req.end();
-}
+  var last_flush = graphiteStats.last_flush || 0;
+  var last_exception = graphiteStats.last_exception || 0;
+  var flush_time = graphiteStats.flush_time || 0;
+  var flush_length = graphiteStats.flush_length || 0;
+  if (apiKey) {
+    var ts = Math.round(new Date().getTime() / 1000);
+    var ts_suffix = ' ' + ts + "\n";
+    var namespace = globalNamespace.concat(prefixStats).join(".");
+    statString += namespace + '.graphiteStats.last_exception' + globalSuffix + last_exception + ts_suffix;
+    statString += namespace + '.graphiteStats.last_flush'     + globalSuffix + last_flush     + ts_suffix;
+    statString += namespace + '.graphiteStats.flush_time'     + globalSuffix + flush_time     + ts_suffix;
+    statString += namespace + '.graphiteStats.flush_length'   + globalSuffix + flush_length   + ts_suffix;
+
+    var options = {
+      host: 'www.hostedgraphite.com',
+      port: 80,
+      path: '/api/v1/sink',
+      method: 'POST',
+      auth: apiKey,
+      headers: {'Content-Length': statString.length}
+    };
+
+    var req = http.request(options, function(res) {
+      if (debug) {
+        l.log("hostedgraphiteStatusCode: " + res.statusCode);
+      }
+    });
+
+    req.on('error', function(ex) {
+      if (debug) {
+        l.log(ex);
+      }
+      graphiteStats.last_exception = Math.round(new Date().getTime() / 1000);
+    });
+
+    var starttime = Date.now();
+    req.write(statString);
+    req.end();
+    graphiteStats.flush_time = (Date.now() - starttime);
+    graphiteStats.flush_length = statString.length;
+    graphiteStats.last_flush = Math.round(new Date().getTime() / 1000);
+  }
+};
 
 var flush_stats = function graphite_flush(ts, metrics) {
+  var ts_suffix = ' ' + ts + "\n";
+  var starttime = Date.now();
   var statString = '';
   var numStats = 0;
   var key;
-
+  var timer_data_key;
   var counters = metrics.counters;
   var gauges = metrics.gauges;
   var timers = metrics.timers;
-  var pctThreshold = metrics.pctThreshold;
+  var sets = metrics.sets;
+  var counter_rates = metrics.counter_rates;
+  var timer_data = metrics.timer_data;
+  var statsd_metrics = metrics.statsd_metrics;
+
+  // Sanitize key for graphite if not done globally
+  function sk(key) {
+    if (globalKeySanitize) {
+      return key;
+    } else {
+      return key.replace(/\s+/g, '_')
+                .replace(/\//g, '-')
+                .replace(/[^a-zA-Z_\-0-9\.]/g, '');
+    }
+  };
 
   for (key in counters) {
     var value = counters[key];
-    var valuePerSecond = value / (flushInterval / 1000); // calculate "per second" rate
+    var valuePerSecond = counter_rates[key]; // pre-calculated "per second" rate
+    var keyName = sk(key);
+    var namespace = counterNamespace.concat(keyName);
 
-    statString += 'stats.'        + key + ' ' + valuePerSecond + ' ' + ts + "\n";
-    statString += 'stats_counts.' + key + ' ' + value          + ' ' + ts + "\n";
+    if (legacyNamespace === true) {
+      statString += namespace.join(".") + globalSuffix + valuePerSecond + ts_suffix;
+      if (flush_counts) {
+        statString += 'stats_counts.' + keyName + globalSuffix + value + ts_suffix;
+      }
+    } else {
+      statString += namespace.concat('rate').join(".") + globalSuffix + valuePerSecond + ts_suffix;
+      if (flush_counts) {
+        statString += namespace.concat('count').join(".") + globalSuffix + value + ts_suffix;
+      }
+    }
 
     numStats += 1;
   }
 
-  for (key in timers) {
-    if (timers[key].length > 0) {
-      var values = timers[key].sort(function (a,b) { return a-b; });
-      var count = values.length;
-      var min = values[0];
-      var max = values[count - 1];
+  for (key in timer_data) {
+    var namespace = timerNamespace.concat(sk(key));
+    var the_key = namespace.join(".");
 
-      var cumulativeValues = [min];
-      for (var i = 1; i < count; i++) {
-          cumulativeValues.push(values[i] + cumulativeValues[i-1]);
-      }
-
-      var sum = min;
-      var mean = min;
-      var maxAtThreshold = max;
-
-      var message = "";
-
-      var key2;
-
-      for (key2 in pctThreshold) {
-        var pct = pctThreshold[key2];
-        if (count > 1) {
-          var thresholdIndex = Math.round(((100 - pct) / 100) * count);
-          var numInThreshold = count - thresholdIndex;
-
-          maxAtThreshold = values[numInThreshold - 1];
-          sum = cumulativeValues[numInThreshold - 1];
-          mean = sum / numInThreshold;
+    for (timer_data_key in timer_data[key]) {
+      if (typeof(timer_data[key][timer_data_key]) === 'number') {
+        statString += the_key + '.' + timer_data_key + globalSuffix + timer_data[key][timer_data_key] + ts_suffix;
+      } else {
+        for (var timer_data_sub_key in timer_data[key][timer_data_key]) {
+          if (debug) {
+            l.log(timer_data[key][timer_data_key][timer_data_sub_key].toString());
+          }
+          statString += the_key + '.' + timer_data_key + '.' + timer_data_sub_key + globalSuffix +
+                        timer_data[key][timer_data_key][timer_data_sub_key] + ts_suffix;
         }
-
-        var clean_pct = '' + pct;
-        clean_pct.replace('.', '_');
-        message += 'stats.timers.' + key + '.mean_'  + clean_pct + ' ' + mean           + ' ' + ts + "\n";
-        message += 'stats.timers.' + key + '.upper_' + clean_pct + ' ' + maxAtThreshold + ' ' + ts + "\n";
-        message += 'stats.timers.' + key + '.sum_' + clean_pct + ' ' + sum + ' ' + ts + "\n";
       }
-
-      sum = cumulativeValues[count-1];
-      mean = sum / count;
-
-      message += 'stats.timers.' + key + '.upper ' + max   + ' ' + ts + "\n";
-      message += 'stats.timers.' + key + '.lower ' + min   + ' ' + ts + "\n";
-      message += 'stats.timers.' + key + '.count ' + count + ' ' + ts + "\n";
-      message += 'stats.timers.' + key + '.sum ' + sum  + ' ' + ts + "\n";
-      message += 'stats.timers.' + key + '.mean ' + mean + ' ' + ts + "\n";
-      statString += message;
-
-      numStats += 1;
     }
+    numStats += 1;
   }
 
   for (key in gauges) {
-    statString += 'stats.gauges.' + key + ' ' + gauges[key] + ' ' + ts + "\n";
+    var namespace = gaugesNamespace.concat(sk(key));
+    statString += namespace.join(".") + globalSuffix + gauges[key] + ts_suffix;
     numStats += 1;
   }
 
-  statString += 'statsd.numStats ' + numStats + ' ' + ts + "\n";
+  for (key in sets) {
+    var namespace = setsNamespace.concat(sk(key));
+    statString += namespace.join(".") + '.count' + globalSuffix + sets[key].values().length + ts_suffix;
+    numStats += 1;
+  }
+
+  var namespace = globalNamespace.concat(prefixStats);
+  if (legacyNamespace === true) {
+    statString += prefixStats + '.numStats' + globalSuffix + numStats + ts_suffix;
+    statString += 'stats.' + prefixStats + '.graphiteStats.calculationtime' + globalSuffix + (Date.now() - starttime) + ts_suffix;
+    for (key in statsd_metrics) {
+      statString += 'stats.' + prefixStats + '.' + key + globalSuffix + statsd_metrics[key] + ts_suffix;
+    }
+  } else {
+    statString += namespace.join(".") + '.numStats' + globalSuffix + numStats + ts_suffix;
+    statString += namespace.join(".") + '.graphiteStats.calculationtime' + globalSuffix + (Date.now() - starttime) + ts_suffix;
+    for (key in statsd_metrics) {
+      var the_key = namespace.concat(key);
+      statString += the_key.join(".") + globalSuffix + statsd_metrics[key] + ts_suffix;
+    }
+  }
   post_stats(statString);
+
+  if (debug) {
+   l.log("numStats: " + numStats);
+  }
 };
 
 var backend_status = function graphite_status(writeCb) {
-  for (stat in graphiteStats) {
+  for (var stat in graphiteStats) {
     writeCb(null, 'hostedgraphite', stat, graphiteStats[stat]);
   }
 };
 
-exports.init = function graphite_init(startup_time, config, events) {
+exports.init = function graphite_init(startup_time, config, events, logger) {
   debug = config.debug;
-  APIKey = config.hostedGraphiteAPIKey;
+  l = logger;
+  apiKey = config.hostedGraphiteAPIKey;
+
+  config.hostedGraphite = config.hostedGraphite || {};
+  globalPrefix          = config.hostedGraphite.globalPrefix;
+  prefixCounter         = config.hostedGraphite.prefixCounter;
+  prefixTimer           = config.hostedGraphite.prefixTimer;
+  prefixGauge           = config.hostedGraphite.prefixGauge;
+  prefixSet             = config.hostedGraphite.prefixSet;
+  globalSuffix          = config.hostedGraphite.globalSuffix;
+  legacyNamespace       = config.hostedGraphite.legacyNamespace;
+  prefixStats           = config.prefixStats;
+
+  // set defaults for prefixes & suffix
+  globalPrefix  = globalPrefix !== undefined ? globalPrefix : "stats";
+  prefixCounter = prefixCounter !== undefined ? prefixCounter : "counters";
+  prefixTimer   = prefixTimer !== undefined ? prefixTimer : "timers";
+  prefixGauge   = prefixGauge !== undefined ? prefixGauge : "gauges";
+  prefixSet     = prefixSet !== undefined ? prefixSet : "sets";
+  prefixStats   = prefixStats !== undefined ? prefixStats : "statsd";
+  legacyNamespace = legacyNamespace !== undefined ? legacyNamespace : true;
+
+  // In order to unconditionally add this string, it either needs to be
+  // a single space if it was unset, OR surrounded by a . and a space if
+  // it was set.
+  globalSuffix  = globalSuffix !== undefined ? '.' + globalSuffix + ' ' : ' ';
+
+  if (legacyNamespace === false) {
+    if (globalPrefix !== "") {
+      globalNamespace.push(globalPrefix);
+      counterNamespace.push(globalPrefix);
+      timerNamespace.push(globalPrefix);
+      gaugesNamespace.push(globalPrefix);
+      setsNamespace.push(globalPrefix);
+    }
+
+    if (prefixCounter !== "") {
+      counterNamespace.push(prefixCounter);
+    }
+    if (prefixTimer !== "") {
+      timerNamespace.push(prefixTimer);
+    }
+    if (prefixGauge !== "") {
+      gaugesNamespace.push(prefixGauge);
+    }
+    if (prefixSet !== "") {
+      setsNamespace.push(prefixSet);
+    }
+  } else {
+      globalNamespace = ['stats'];
+      counterNamespace = ['stats'];
+      timerNamespace = ['stats', 'timers'];
+      gaugesNamespace = ['stats', 'gauges'];
+      setsNamespace = ['stats', 'sets'];
+  }
 
   graphiteStats.last_flush = startup_time;
   graphiteStats.last_exception = startup_time;
+  graphiteStats.flush_time = 0;
+  graphiteStats.flush_length = 0;
+
+  if (config.keyNameSanitize !== undefined) {
+    globalKeySanitize = config.keyNameSanitize;
+  }
 
   flushInterval = config.flushInterval;
+
+  flush_counts = typeof(config.flush_counts) === "undefined" ? true : config.flush_counts;
 
   events.on('flush', flush_stats);
   events.on('status', backend_status);


### PR DESCRIPTION
Adds feature parity to the hosted graphite backend to match the latest [graphite backend (v0.7.2)](https://github.com/etsy/statsd/blob/v0.7.2/backends/graphite.js). The original hosted graphite backend appears to be based on [graphite backend v0.4.0](https://github.com/etsy/statsd/blob/v0.4.0/backends/graphite.js) which is about 3 years old now.

In the statsd config, a `hostedGraphite` section can now be defined, just like the graphite backend. This will also address pull https://github.com/hostedgraphite/statsdplugin/pull/1 which was done to add a `globalPrefix`

```
hostedGraphite:
    legacyNamespace:  use the legacy namespace [default: true]
    globalPrefix:     global prefix to use for sending stats to graphite [default: "stats"]
    prefixCounter:    graphite prefix for counter metrics [default: "counters"]
    prefixTimer:      graphite prefix for timer metrics [default: "timers"]
    prefixGauge:      graphite prefix for gauge metrics [default: "gauges"]
    prefixSet:        graphite prefix for set metrics [default: "sets"]
    globalSuffix:     global suffix to use for sending stats to graphite [default: ""]
                      This is particularly useful for sending per host stats by
                      settings this value to: require('os').hostname().split('.')[0]
```
